### PR TITLE
wrapping bind in an optional stmt

### DIFF
--- a/login_service/sparql_queries.rb
+++ b/login_service/sparql_queries.rb
@@ -90,7 +90,7 @@ module LoginService
       query += "             <#{RDF::Vocab::FOAF.account}> ?uri ;"
       query += "             <#{RDF::Vocab::FOAF.member}> ?group ."
       query += "   }"
-      query += "   BIND(IRI(CONCAT(\"http://mu.semte.ch/graphs/organizations/\", ?group_uuid)) as ?g)"
+      query += "   optional {BIND(IRI(CONCAT(\"http://mu.semte.ch/graphs/organizations/\", ?group_uuid)) as ?g)}"
       query += " }"
       query(query)
     end
@@ -120,7 +120,7 @@ module LoginService
       query += "             <#{RDF::Vocab::FOAF.account}> ?uri ;"
       query += "             <#{RDF::Vocab::FOAF.member}> ?group ."
       query += "   }"
-      query += "   BIND(IRI(CONCAT(\"http://mu.semte.ch/graphs/organizations/\", ?group_uuid)) as ?g)"
+      query += "   optional {BIND(IRI(CONCAT(\"http://mu.semte.ch/graphs/organizations/\", ?group_uuid)) as ?g)}"
       query += " }"
       query(query)
     end


### PR DESCRIPTION
When using other sparql endpoint than virtuoso (e.g fuseki), the queries are considered incorrect:
`BIND: Variable used when already in-scope`