### PR TITLE
Remove specific session only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM semtech/mu-ruby-template:2.6.0-ruby2.3
+FROM semtech/mu-ruby-template:3.1.0
 
 MAINTAINER Erika Pauwels <erika.pauwels@gmail.com>
 

--- a/login_service/sparql_queries.rb
+++ b/login_service/sparql_queries.rb
@@ -64,12 +64,11 @@ module LoginService
       query(query)
     end
 
-    def delete_current_session(account)
+    def delete_current_session(session)
       query= %(
         DELETE WHERE {
            GRAPH <http://mu.semte.ch/graphs/sessions> {
-             ?session <#{MU_SESSION.account}> <#{account}>;
-               ?p ?o.
+             <#{session}> ?p ?o .
            }
          })
       update(query)

--- a/web.rb
+++ b/web.rb
@@ -84,7 +84,7 @@ post '/sessions/' do
   ###
   # Insert new session
   ###
-  session_id = generate_uuid()
+  session_id = Mu::generate_uuid()
   insert_new_session_for_account(account[:uri].to_s, session_uri, session_id, group[:group].to_s, group_id, roles)
 
   status 201

--- a/web.rb
+++ b/web.rb
@@ -142,19 +142,18 @@ delete '/sessions/current/?' do
 
 
   ###
-  # Get account
+  # Error out if no account is attached to a session
   ###
 
   result = select_account_by_session(session_uri)
   error('Invalid session') if result.empty?
-  account = result.first[:account].to_s
 
 
   ###
   # Remove session
   ###
 
-  delete_current_session(account)
+  delete_current_session(session_uri)
 
   status 204
   headers['mu-auth-allowed-groups'] = 'CLEAR'


### PR DESCRIPTION
## Description

In previous version of this service and when logging in to the same organization through two different browsers, logging out from one of them caused the session in the other browser to forcibly log out as well.

## How to Test

Add the following to your `docker-compose.override.yml` file:

```yml
mocklogin:
    image: lblod/mock-login-service:0.6.0-beta.1
```

* Open two incognito browser windows (e.g., one on Firefox and one on Chromium) and log in using the same organization (e.g., `Gemeente Aalst`).
* Log out from one of the browser windows.
* Refresh the tab on the other window -> The session should stay logged in.