### PR TITLE
Feature/mock login verenigingen

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ The host `login` in the forward URL reflects the name of the login service in th
 
 More information how to setup a mu.semte.ch project can be found in [mu-project](https://github.com/mu-semtech/mu-project).
 
+## Environment Variables
+This project uses the following environment variables:
+
+| Variable    | Description                                                                                      | Default Value                                                | Required |
+|-------------|--------------------------------------------------------------------------------------------------|--------------------------------------------------------------|----------|
+| GROUP_TYPE  | Used as the `rdf:type` of the group related to the account that is logging in.                   | `http://data.vlaanderen.be/ns/besluit#Bestuurseenheid`       | No       |
+
+
 
 ## Available requests
 

--- a/login_service/sparql_queries.rb
+++ b/login_service/sparql_queries.rb
@@ -42,7 +42,7 @@ module LoginService
       query += "                  <#{MU_EXT.sessionGroup}> ?group ."
       query += "   }"
       query += "   GRAPH <#{graph}> {"
-      query += "     ?group a <#{BESLUIT.Bestuurseenheid}> ;"
+      query += "     ?group a <#{ORG.Organization}> ;"
       query += "            <#{MU_CORE.uuid}> ?group_uuid ."
       query += "   }"
       query += "   GRAPH ?g {"
@@ -78,7 +78,7 @@ module LoginService
     def select_account(id)
       query =  " SELECT ?uri WHERE {"
       query += "   GRAPH <#{graph}> {"
-      query += "     ?group a <#{BESLUIT.Bestuurseenheid}> ;"
+      query += "     ?group a <#{ORG.Organization}> ;"
       query += "            <#{MU_CORE.uuid}> ?group_uuid ."
       query += "   }"
       query += "   GRAPH ?g {"
@@ -96,7 +96,7 @@ module LoginService
     def select_group(group_id)
       query =  " SELECT ?group WHERE {"
       query += "   GRAPH <#{graph}> {"
-      query += "      ?group a <#{BESLUIT.Bestuurseenheid}> ;"
+      query += "      ?group a <#{ORG.Organization}> ;"
       query += "               <#{MU_CORE.uuid}> \"#{group_id}\" ."
       query += "   }"
       query += " }"
@@ -107,7 +107,7 @@ module LoginService
     def select_roles(account_id)
       query =  " SELECT ?role WHERE {"
       query += "   GRAPH <#{graph}> {"
-      query += "     ?group a <#{BESLUIT.Bestuurseenheid}> ;"
+      query += "     ?group a <#{ORG.Organization}> ;"
       query += "            <#{MU_CORE.uuid}> ?group_uuid ."
       query += "   }"
       query += "   GRAPH ?g {"

--- a/login_service/sparql_queries.rb
+++ b/login_service/sparql_queries.rb
@@ -42,7 +42,7 @@ module LoginService
       query += "                  <#{MU_EXT.sessionGroup}> ?group ."
       query += "   }"
       query += "   GRAPH <#{graph}> {"
-      query += "     ?group a <#{ORG.Organization}> ;"
+      query += "     ?group a <#{GROUP_TYPE}> ;"
       query += "            <#{MU_CORE.uuid}> ?group_uuid ."
       query += "   }"
       query += "   GRAPH ?g {"
@@ -78,7 +78,7 @@ module LoginService
     def select_account(id)
       query =  " SELECT ?uri WHERE {"
       query += "   GRAPH <#{graph}> {"
-      query += "     ?group a <#{ORG.Organization}> ;"
+      query += "     ?group a <#{GROUP_TYPE}> ;"
       query += "            <#{MU_CORE.uuid}> ?group_uuid ."
       query += "   }"
       query += "   GRAPH ?g {"
@@ -96,7 +96,7 @@ module LoginService
     def select_group(group_id)
       query =  " SELECT ?group WHERE {"
       query += "   GRAPH <#{graph}> {"
-      query += "      ?group a <#{ORG.Organization}> ;"
+      query += "      ?group a <#{GROUP_TYPE}> ;"
       query += "               <#{MU_CORE.uuid}> \"#{group_id}\" ."
       query += "   }"
       query += " }"
@@ -107,7 +107,7 @@ module LoginService
     def select_roles(account_id)
       query =  " SELECT ?role WHERE {"
       query += "   GRAPH <#{graph}> {"
-      query += "     ?group a <#{ORG.Organization}> ;"
+      query += "     ?group a <#{GROUP_TYPE}> ;"
       query += "            <#{MU_CORE.uuid}> ?group_uuid ."
       query += "   }"
       query += "   GRAPH ?g {"

--- a/web.rb
+++ b/web.rb
@@ -11,6 +11,7 @@ include AuthExtensions::Sudo
 MU_ACCOUNT = RDF::Vocabulary.new(MU.to_uri.to_s + 'account/')
 MU_SESSION = RDF::Vocabulary.new(MU.to_uri.to_s + 'session/')
 BESLUIT =  RDF::Vocabulary.new('http://data.vlaanderen.be/ns/besluit#')
+ORG =  RDF::Vocabulary.new('http://www.w3.org/ns/org#')
 
 ###
 # POST /sessions

--- a/web.rb
+++ b/web.rb
@@ -10,8 +10,13 @@ include AuthExtensions::Sudo
 
 MU_ACCOUNT = RDF::Vocabulary.new(MU.to_uri.to_s + 'account/')
 MU_SESSION = RDF::Vocabulary.new(MU.to_uri.to_s + 'session/')
-BESLUIT =  RDF::Vocabulary.new('http://data.vlaanderen.be/ns/besluit#')
-ORG =  RDF::Vocabulary.new('http://www.w3.org/ns/org#')
+BESLUIT = RDF::Vocabulary.new('http://data.vlaanderen.be/ns/besluit#')
+
+###
+# ENV Variables
+###
+
+GROUP_TYPE = ENV['GROUP_TYPE'] || BESLUIT.Bestuurseenheid
 
 ###
 # POST /sessions


### PR DESCRIPTION
DGS-231

--------------
This PR updates the queries to look for org:Organizations instead of besluit:Bestuurseenheid if GROUP_TYPE is set as ENV. Notice that org is the parent of a bestuurseenheid. This just broadens the types that can login using mock login to all organizations and their children. 

Main PR:
https://github.com/lblod/app-subsidiepunt/pull/22